### PR TITLE
Fix Goodix support.

### DIFF
--- a/build/tools/edit_ramdisk.sh
+++ b/build/tools/edit_ramdisk.sh
@@ -151,3 +151,20 @@ echo "" >> $CONFIGFILE
 echo "on property:dev.bootcomplete=1" >> $CONFIGFILE
 echo "# SET IO SCHEDULER" >> $CONFIGFILE
 echo "setprop sys.io.scheduler \"fiops\"" >> $CONFIGFILE
+goodix=$(cat /tmp/aroma/goodix.prop | cut -d '=' -f2)
+if ([ $goodix -eq 1 ]); then
+cat >> $CONFIGFILE <<EOF
+echo "# Goodix FP Sensor" >> $CONFIGFILE
+chown system system  /dev/goodix_fp
+chmod 0644 /dev/goodix_fp
+
+service gx_fpd /system/bin/gx_fpd
+    class late_start
+    user system
+    group system
+    disabled
+
+on property:persist.sys.fp.sensor=goodix
+    start gx_fpd
+EOF
+fi

--- a/build/tools/edit_ramdisk.sh
+++ b/build/tools/edit_ramdisk.sh
@@ -152,7 +152,7 @@ echo "on property:dev.bootcomplete=1" >> $CONFIGFILE
 echo "# SET IO SCHEDULER" >> $CONFIGFILE
 echo "setprop sys.io.scheduler \"fiops\"" >> $CONFIGFILE
 goodix=$(cat /tmp/aroma/goodix.prop | cut -d '=' -f2)
-if ([ $goodix -eq 1 ]); then
+if ([ $goodix -eq 2 ]); then
 cat >> $CONFIGFILE <<EOF
 echo "# Goodix FP Sensor" >> $CONFIGFILE
 chown system system  /dev/goodix_fp


### PR DESCRIPTION
I found Goodix unusable after migrating to LineageOS.

```
02-08 12:11:13.642  7818  7818 D FingerGoodix: FingerPrint, getService failed, try again later.
02-08 12:11:14.143  7818  7818 E FingerGoodix: fingerprintService is null
02-08 12:11:14.143  7818  7818 E FingerGoodix:  retry times left expired!
02-08 12:12:00.254 10158 10158 E FingerGoodix: linkToDeath Failed!
02-08 12:12:00.254 10158 10158 D FingerGoodix: fpcode, goodix_sensor_init(), Fp::connect failed!
02-08 12:12:00.254 10158 10158 E FingerGoodix: Init goodix sensor failed!
```

I executed `gx_fpd` in shell manually, and the sensor worked. I think patching ramfs makes Goodix great again!