### PR TITLE
clk should init first before probing i2c

### DIFF
--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -98,6 +98,8 @@ obj-$(CONFIG_GAMEPORT)		+= input/gameport/
 obj-$(CONFIG_INPUT)		+= input/
 obj-$(CONFIG_I2O)		+= message/
 obj-$(CONFIG_RTC_LIB)		+= rtc/
+#common clk code
+obj-y				+= clk/
 obj-y				+= i2c/ media/
 obj-$(CONFIG_PPS)		+= pps/
 obj-$(CONFIG_PTP_1588_CLOCK)	+= ptp/
@@ -138,8 +140,7 @@ obj-$(CONFIG_VHOST_RING)	+= vhost/
 obj-$(CONFIG_VLYNQ)		+= vlynq/
 obj-$(CONFIG_STAGING)		+= staging/
 obj-y				+= platform/
-#common clk code
-obj-y				+= clk/
+
 
 obj-$(CONFIG_MAILBOX)		+= mailbox/
 obj-$(CONFIG_HWSPINLOCK)	+= hwspinlock/


### PR DESCRIPTION
This problem relates to the driver probe order. Because clk inits after probing i2c, so that i2c failed to get clk. Moving clk upto a higher position than i2c will fix the error message.